### PR TITLE
refactor: make the HTTP client injectable across modules

### DIFF
--- a/go/epa/session.go
+++ b/go/epa/session.go
@@ -37,6 +37,36 @@ func WithTimeout(timeout time.Duration) ClientOption {
 	}
 }
 
+// WithHTTPClient supplies the base HTTP client. The epa client layers its TLS settings and
+// User-Agent onto a copy of it; when unset, a client with a default timeout is created.
+func WithHTTPClient(client *http.Client) ClientOption {
+	return func(c *Client) {
+		c.HttpClient = client
+	}
+}
+
+const defaultHTTPTimeout = 5 * time.Second
+
+func transportOrDefault(rt http.RoundTripper) http.RoundTripper {
+	if rt == nil {
+		return http.DefaultTransport
+	}
+	return rt
+}
+
+// transportWithTLS clones the base transport (or http.DefaultTransport when the base is nil or not a
+// *http.Transport) and applies the given TLS config, layering epa's TLS settings onto the chosen
+// client without mutating it.
+func transportWithTLS(rt http.RoundTripper, tlsConfig *tls.Config) http.RoundTripper {
+	base, ok := transportOrDefault(rt).(*http.Transport)
+	if !ok {
+		base = http.DefaultTransport.(*http.Transport)
+	}
+	t := base.Clone()
+	t.TLSClientConfig = tlsConfig
+	return t
+}
+
 type SecurityFunctions struct {
 	AuthnSignFunc           brainpool.SignFunc
 	AuthnCertFunc           func() (*x509.Certificate, error)
@@ -141,24 +171,24 @@ func NewClient(env Env, provider ProviderNumber, sf *SecurityFunctions, options 
 		option(client)
 	}
 
-	transport := &http.Transport{
-		TLSClientConfig: &tls.Config{
+	base := client.HttpClient
+	if base == nil {
+		base = &http.Client{Timeout: defaultHTTPTimeout}
+	}
+	// layer epa's TLS settings and User-Agent onto the chosen client without mutating the caller's
+	decorated := *base
+	decorated.Transport = &customTransport{
+		t: transportWithTLS(base.Transport, &tls.Config{
 			InsecureSkipVerify: client.insecureSkipVerify,
 			RootCAs:            client.certPool,
-		},
+		}),
 	}
-
-	client.HttpClient = &http.Client{
-		Transport: &customTransport{
-			t: transport,
-		},
-	}
-
 	if client.Timeout > 0 {
-		client.HttpClient.Timeout = client.Timeout
-	} else {
-		client.HttpClient.Timeout = 5 * time.Second
+		decorated.Timeout = client.Timeout
+	} else if decorated.Timeout == 0 {
+		decorated.Timeout = defaultHTTPTimeout
 	}
+	client.HttpClient = &decorated
 
 	client.BaseURL = ResolveBaseURL(env, provider)
 

--- a/go/gemidp/authenticator.go
+++ b/go/gemidp/authenticator.go
@@ -59,17 +59,27 @@ type Authenticator struct {
 	Metadata    Metadata
 	baseURL     string
 	signerFunc  ChallengeSignerFunc
+	httpClient  *http.Client
 }
 
 type AuthenticatorConfig struct {
 	Idp        Idp
 	SignerFunc ChallengeSignerFunc
+
+	// HTTPClient is used for metadata and key fetches; a redirect-suppressing copy of it drives the
+	// challenge flow. When nil, a client with a default timeout is created.
+	HTTPClient *http.Client
 }
 
 // NewAuthenticator creates a new Authenticator
 func NewAuthenticator(config AuthenticatorConfig) (*Authenticator, error) {
+	httpClient := config.HTTPClient
+	if httpClient == nil {
+		httpClient = &http.Client{Timeout: defaultHTTPTimeout}
+	}
+
 	baseURL := config.Idp.baseURL
-	metadata, err := fetchMetadata(baseURL, http.DefaultClient)
+	metadata, err := fetchMetadata(baseURL, httpClient)
 	if err != nil {
 		return nil, err
 	}
@@ -79,6 +89,7 @@ func NewAuthenticator(config AuthenticatorConfig) (*Authenticator, error) {
 		Metadata:    *metadata,
 		baseURL:     baseURL,
 		signerFunc:  config.SignerFunc,
+		httpClient:  httpClient,
 	}, nil
 }
 
@@ -96,22 +107,23 @@ type CodeRedirectURL struct {
 func (a *Authenticator) Authenticate(authURL string) (*CodeRedirectURL, error) {
 	// fetch fresh keys
 	// encrypt the signed challenge response for the idp
-	idpEncKey, err := fetchKey(a.Metadata.EncryptionKeyURI)
+	idpEncKey, err := fetchKey(a.Metadata.EncryptionKeyURI, a.httpClient)
 	if err != nil {
 		return nil, fmt.Errorf("fetching challenge encryption key: %w", err)
 	}
-	idpSigKey, err := fetchKey(a.Metadata.SigningKeyURI)
+	idpSigKey, err := fetchKey(a.Metadata.SigningKeyURI, a.httpClient)
 	if err != nil {
 		return nil, fmt.Errorf("fetching challenge signing key: %w", err)
 	}
 	slog.Warn("IDP Authenticator is using signing and encryption keys with unverified certificates")
 
-	// create http client which prevents redirects
-	httpClient := http.Client{
-		CheckRedirect: func(req *http.Request, via []*http.Request) error {
-			return http.ErrUseLastResponse
-		},
+	// derive a redirect-suppressing client from the injected one (the challenge flow inspects the
+	// 302 Location itself), without mutating the caller's client
+	noFollow := *a.httpClient
+	noFollow.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+		return http.ErrUseLastResponse
 	}
+	httpClient := &noFollow
 
 	resp, err := httpClient.Get(authURL)
 	if err != nil {

--- a/go/gemidp/client.go
+++ b/go/gemidp/client.go
@@ -56,6 +56,11 @@ type ClientConfig struct {
 	Scopes            []string    `yaml:"scopes"`
 	AuthenticatorMode bool        `yaml:"authenticator_mode"`
 	UserAgent         string      `yaml:"user_agent"`
+
+	// HTTPClient is used for metadata, key, and token requests. Not serialized; supplied
+	// programmatically. When nil, a client with a default timeout is created. The configured
+	// User-Agent is layered onto the client's transport either way.
+	HTTPClient *http.Client `yaml:"-"`
 }
 
 type Client struct {
@@ -89,9 +94,14 @@ func NewClientFromConfig(config ClientConfig) (*Client, error) {
 
 	baseURL := idp.baseURL
 
-	httpClient := &http.Client{
-		Transport: &transportAddUserAgent{http.DefaultTransport, config.UserAgent},
+	httpClient := config.HTTPClient
+	if httpClient == nil {
+		httpClient = &http.Client{Timeout: defaultHTTPTimeout}
 	}
+	// layer the gematik User-Agent onto the chosen client without mutating the caller's
+	decorated := *httpClient
+	decorated.Transport = &transportAddUserAgent{transportOrDefault(httpClient.Transport), config.UserAgent}
+	httpClient = &decorated
 
 	metadata, err := fetchMetadata(baseURL, httpClient)
 	if err != nil {
@@ -179,7 +189,7 @@ func (c *Client) ExchangeForIdentity(code, verifier string, options ...oidc.Opti
 		return nil, fmt.Errorf("generating token key: %w", err)
 	}
 
-	idpEncKey, err := fetchKey(c.Metadata.EncryptionKeyURI)
+	idpEncKey, err := fetchKey(c.Metadata.EncryptionKeyURI, c.httpClient)
 	if err != nil {
 		return nil, fmt.Errorf("fetching challenge encryption key: %w", err)
 	}
@@ -264,7 +274,7 @@ func decryptToken(token string, key []byte) (string, error) {
 }
 
 func (c *Client) parseIDToken(response *oidc.TokenResponse) (jwt.Token, error) {
-	key, err := fetchKey(c.Metadata.SigningKeyURI)
+	key, err := fetchKey(c.Metadata.SigningKeyURI, c.httpClient)
 	if err != nil {
 		return nil, fmt.Errorf("fetching signing key: %w", err)
 	}

--- a/go/gemidp/shared.go
+++ b/go/gemidp/shared.go
@@ -9,10 +9,22 @@ import (
 	"log/slog"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/gematik/zero-lab/go/brainpool"
 	"github.com/gematik/zero-lab/go/brainpool/josebp"
 )
+
+const defaultHTTPTimeout = 30 * time.Second
+
+// transportOrDefault returns http.DefaultTransport when rt is nil, so a decorated client always
+// has a concrete base transport to wrap.
+func transportOrDefault(rt http.RoundTripper) http.RoundTripper {
+	if rt == nil {
+		return http.DefaultTransport
+	}
+	return rt
+}
 
 // Environment of the gematik IDP-Dienst
 type Environment int
@@ -158,8 +170,8 @@ func extractKeyFromX5CHeader(data []byte) (*josebp.JSONWebKey, error) {
 }
 
 // fetch and parse JWK from the given URI
-func fetchKey(uri string) (*josebp.JSONWebKey, error) {
-	resp, err := http.Get(uri)
+func fetchKey(uri string, httpClient *http.Client) (*josebp.JSONWebKey, error) {
+	resp, err := httpClient.Get(uri)
 	if err != nil {
 		return nil, fmt.Errorf("fetching JWK: %w", err)
 	}

--- a/go/gempki/hashlist.go
+++ b/go/gempki/hashlist.go
@@ -211,7 +211,7 @@ func (l HashListNetworkLoader) Load(ctx context.Context) (*HashListChecker, erro
 	}
 	client := l.HTTPClient
 	if client == nil {
-		client = http.DefaultClient
+		client = defaultHTTPClient
 	}
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, l.URL, http.NoBody)
 	if err != nil {

--- a/go/gempki/httpclient.go
+++ b/go/gempki/httpclient.go
@@ -1,0 +1,13 @@
+package gempki
+
+import (
+	"net/http"
+	"time"
+)
+
+const defaultHTTPTimeout = 30 * time.Second
+
+// defaultHTTPClient is the bounded fallback used when a caller passes a nil *http.Client. Production
+// callers should pass their own configured client; this ensures even the fallback carries a timeout
+// rather than the unbounded http.DefaultClient.
+var defaultHTTPClient = &http.Client{Timeout: defaultHTTPTimeout}

--- a/go/gempki/ocsp.go
+++ b/go/gempki/ocsp.go
@@ -38,7 +38,7 @@ const (
 // always takes a caller-supplied [*http.Client] and propagates
 // [context.Context] from Check through to the HTTP layer — production
 // callers can wire timeouts, proxies, TLS pinning, and tracing via the
-// client. A nil HTTPClient falls back to [http.DefaultClient] for tests; do
+// client. A nil HTTPClient falls back to a bounded default client for tests; do
 // not rely on the fallback in production.
 //
 // OCSPChecker is safe for concurrent use.
@@ -183,7 +183,7 @@ func (c *OCSPChecker) Check(ctx context.Context, cert, issuer *x509.Certificate)
 func (c *OCSPChecker) post(ctx context.Context, urlStr string, body []byte) ([]byte, error) {
 	client := c.HTTPClient
 	if client == nil {
-		client = http.DefaultClient
+		client = defaultHTTPClient
 	}
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, urlStr, bytes.NewReader(body))
 	if err != nil {

--- a/go/gempki/truststore_loader.go
+++ b/go/gempki/truststore_loader.go
@@ -167,7 +167,7 @@ func (l FileLoader) Load(_ context.Context) (*TrustStore, error) {
 
 // NetworkLoader fetches roots.json from the gematik distribution endpoint
 // for the configured Environment. HTTPClient is optional; nil falls back to
-// [http.DefaultClient] — production callers should pass a configured client
+// a bounded default client — production callers should pass a configured client
 // with appropriate timeouts.
 type NetworkLoader struct {
 	Env        Environment
@@ -186,7 +186,7 @@ func (l NetworkLoader) Load(ctx context.Context) (*TrustStore, error) {
 	}
 	client := l.HTTPClient
 	if client == nil {
-		client = http.DefaultClient
+		client = defaultHTTPClient
 	}
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, http.NoBody)
 	if err != nil {

--- a/go/gempki/tsl_signature.go
+++ b/go/gempki/tsl_signature.go
@@ -215,7 +215,7 @@ func VerifyTSLDetachedSignatureForEnv(
 }
 
 // LoadTSLDetachedSignature fetches the .sig file at sigURL and parses it.
-// Honours the caller-supplied [*http.Client] (nil → [http.DefaultClient])
+// Honours the caller-supplied [*http.Client] (nil → a bounded default client)
 // and propagates ctx for cancellation and timeouts — per the project's
 // HTTPS-everywhere rule.
 //
@@ -226,7 +226,7 @@ func LoadTSLDetachedSignature(ctx context.Context, httpClient *http.Client, sigU
 		return nil, fmt.Errorf("gempki: LoadTSLDetachedSignature requires a sigURL")
 	}
 	if httpClient == nil {
-		httpClient = http.DefaultClient
+		httpClient = defaultHTTPClient
 	}
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, sigURL, http.NoBody)
 	if err != nil {

--- a/go/kon/client.go
+++ b/go/kon/client.go
@@ -12,6 +12,7 @@ import (
 	"regexp"
 	"slices"
 	"strconv"
+	"time"
 
 	"github.com/gematik/zero-lab/go/pkcs12"
 	"github.com/gematik/zero-lab/go/pkcs12/legacy"
@@ -35,11 +36,28 @@ type Client struct {
 // NewHTTPClient creates an http.Client and base URL from a Dotkon config.
 // It configures TLS and credentials but does not contact the Konnektor.
 func NewHTTPClient(config *Dotkon) (*http.Client, *url.URL, error) {
-	transport := &http.Transport{
-		TLSClientConfig: &tls.Config{
-			ServerName:         config.ExpectedHost,
-			InsecureSkipVerify: config.InsecureSkipVerify,
-		},
+	return newConnectorClient(config, nil, defaultClientConfig().LongTimeout)
+}
+
+// newConnectorClient builds the Konnektor mutual-TLS client and base URL. A non-nil base seeds the
+// transport (cloned) and timeout, so a caller-supplied client controls proxy/timeout while the
+// Konnektor TLS and credentials are layered on without mutating it. When base carries no timeout,
+// the given timeout (the configured LongTimeout) bounds a request so it can never hang forever;
+// per-operation context deadlines bound normal calls more tightly.
+func newConnectorClient(config *Dotkon, base *http.Client, timeout time.Duration) (*http.Client, *url.URL, error) {
+	var transport *http.Transport
+	if base != nil {
+		if bt, ok := base.Transport.(*http.Transport); ok && bt != nil {
+			transport = bt.Clone()
+		} else {
+			transport = http.DefaultTransport.(*http.Transport).Clone()
+		}
+	} else {
+		transport = &http.Transport{}
+	}
+	transport.TLSClientConfig = &tls.Config{
+		ServerName:         config.ExpectedHost,
+		InsecureSkipVerify: config.InsecureSkipVerify,
 	}
 
 	if len(config.TrustedCertificates) > 0 && !config.InsecureSkipVerify {
@@ -98,6 +116,11 @@ func NewHTTPClient(config *Dotkon) (*http.Client, *url.URL, error) {
 	httpClient := &http.Client{
 		Transport: transport,
 	}
+	if base != nil && base.Timeout > 0 {
+		httpClient.Timeout = base.Timeout
+	} else {
+		httpClient.Timeout = timeout
+	}
 
 	if config.Credentials != nil {
 		switch cred := config.Credentials.(type) {
@@ -132,7 +155,7 @@ func NewClient(dotkon *Dotkon, opts ...ClientOption) (*Client, error) {
 		opt(config)
 	}
 
-	httpClient, baseURL, err := NewHTTPClient(dotkon)
+	httpClient, baseURL, err := newConnectorClient(dotkon, config.HTTPClient, config.LongTimeout)
 	if err != nil {
 		return nil, err
 	}

--- a/go/kon/client_config.go
+++ b/go/kon/client_config.go
@@ -1,6 +1,9 @@
 package kon
 
-import "time"
+import (
+	"net/http"
+	"time"
+)
 
 // ClientConfig holds client-side behavior settings (timeouts, etc.)
 // that are independent of the Konnektor connection configuration (Dotkon).
@@ -9,6 +12,9 @@ type ClientConfig struct {
 	ShortTimeout time.Duration
 	// LongTimeout is used for long-running operations like signing and encryption.
 	LongTimeout time.Duration
+	// HTTPClient is the base client; the Konnektor's mutual-TLS settings are layered onto a copy of
+	// it. When nil, a client is built from the Dotkon config with a default timeout.
+	HTTPClient *http.Client
 }
 
 // ClientOption configures a Client.
@@ -18,6 +24,13 @@ type ClientOption func(*ClientConfig)
 func WithClientConfig(cfg *ClientConfig) ClientOption {
 	return func(c *ClientConfig) {
 		*c = *cfg
+	}
+}
+
+// WithHTTPClient supplies the base HTTP client used to reach the Konnektor.
+func WithHTTPClient(client *http.Client) ClientOption {
+	return func(c *ClientConfig) {
+		c.HTTPClient = client
 	}
 }
 

--- a/go/oauth/oidc/client.go
+++ b/go/oauth/oidc/client.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"time"
 
 	"github.com/lestrrat-go/httprc/v3"
 	"github.com/lestrrat-go/jwx/v3/jwk"
@@ -16,6 +17,8 @@ import (
 	"github.com/lestrrat-go/jwx/v3/jwt"
 	"golang.org/x/oauth2"
 )
+
+const defaultHTTPTimeout = 30 * time.Second
 
 type Config struct {
 	Issuer       string       `yaml:"issuer" validate:"required"`
@@ -25,31 +28,39 @@ type Config struct {
 	Scopes       []string     `yaml:"scopes"`
 	LogoURI      string       `yaml:"logo_uri"`
 	Name         string       `yaml:"name"`
+
+	// HTTPClient is used for discovery, the key cache, and token exchange. Not serialized; supplied
+	// programmatically. When nil, a client with a default timeout is created.
+	HTTPClient *http.Client `yaml:"-"`
 }
 
 type client struct {
 	cfg               Config
+	httpClient        *http.Client
 	discoveryDocument *DiscoveryDocument
 	keyCache          *jwk.Cache
 }
 
 func NewClient(cfg Config) (Client, error) {
+	httpClient := cfg.HTTPClient
+	if httpClient == nil {
+		httpClient = &http.Client{Timeout: defaultHTTPTimeout}
+	}
 	c := &client{
-		cfg:               cfg,
-		discoveryDocument: nil,
-		keyCache:          nil,
+		cfg:        cfg,
+		httpClient: httpClient,
 	}
 
 	var err error
 	discoveryDocumentUrl := cfg.Issuer + "/.well-known/openid-configuration"
-	c.discoveryDocument, err = FetchDiscoveryDocument(discoveryDocumentUrl)
+	c.discoveryDocument, err = FetchDiscoveryDocument(discoveryDocumentUrl, httpClient)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch discovery document from %s: %w", discoveryDocumentUrl, err)
 	}
 
 	// prepare the auto-refreshing signing key cache
 	context := context.Background()
-	c.keyCache, err = jwk.NewCache(context, httprc.NewClient())
+	c.keyCache, err = jwk.NewCache(context, httprc.NewClient(httprc.WithHTTPClient(httpClient)))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create key cache: %w", err)
 	}
@@ -117,7 +128,7 @@ func (c *client) ExchangeForIdentity(code, verifier string, options ...Option) (
 
 	slog.Debug("Exchanging code for token", "url", c.discoveryDocument.TokenEndpoint, "params", params)
 
-	resp, err := http.PostForm(c.discoveryDocument.TokenEndpoint, params)
+	resp, err := c.httpClient.PostForm(c.discoveryDocument.TokenEndpoint, params)
 	if err != nil {
 		return nil, fmt.Errorf("unable to exchange code for token: %w", err)
 	}

--- a/go/oauth/oidc/discovery.go
+++ b/go/oauth/oidc/discovery.go
@@ -17,8 +17,8 @@ type DiscoveryDocument struct {
 	IdTokenSigningAlgValuesSupported []string `json:"id_token_signing_alg_values_supported"`
 }
 
-func FetchDiscoveryDocument(url string) (*DiscoveryDocument, error) {
-	resp, err := http.Get(string(url))
+func FetchDiscoveryDocument(url string, httpClient *http.Client) (*DiscoveryDocument, error) {
+	resp, err := httpClient.Get(url)
 	if err != nil {
 		return nil, fmt.Errorf("unable to get discovery document: %w", err)
 	}

--- a/go/oidf/oidf.go
+++ b/go/oidf/oidf.go
@@ -14,6 +14,17 @@ import (
 	"github.com/lestrrat-go/jwx/v3/jwt"
 )
 
+const defaultHTTPTimeout = 30 * time.Second
+
+// transportOrDefault returns http.DefaultTransport when rt is nil, so a decorated client always
+// has a concrete base transport to wrap.
+func transportOrDefault(rt http.RoundTripper) http.RoundTripper {
+	if rt == nil {
+		return http.DefaultTransport
+	}
+	return rt
+}
+
 type OpenidFederation struct {
 	fedMasterURL string
 	jwks         jwk.Set
@@ -39,19 +50,43 @@ type IdentityProviderInfo struct {
 	UserType         UserType `json:"user_type_supported"`
 }
 
-func NewOpenidFederation(fedMasterURL string, jwks jwk.Set) (*OpenidFederation, error) {
-	es, err := fetchMasterEntityStatement(fedMasterURL, jwks)
+// Option configures an OpenidFederation.
+type Option func(*federationOptions)
+
+type federationOptions struct {
+	httpClient *http.Client
+}
+
+// WithHTTPClient supplies the base HTTP client; the federation API key is layered onto a copy of it.
+// When unset, a client with a default timeout is created.
+func WithHTTPClient(httpClient *http.Client) Option {
+	return func(o *federationOptions) {
+		o.httpClient = httpClient
+	}
+}
+
+func NewOpenidFederation(fedMasterURL string, jwks jwk.Set, opts ...Option) (*OpenidFederation, error) {
+	o := &federationOptions{}
+	for _, opt := range opts {
+		opt(o)
+	}
+
+	httpClient := o.httpClient
+	if httpClient == nil {
+		httpClient = &http.Client{Timeout: defaultHTTPTimeout}
+	}
+	// layer the federation API key onto the chosen client without mutating the caller's
+	decorated := *httpClient
+	decorated.Transport = AddApiKeyTransport(transportOrDefault(httpClient.Transport))
+	httpClient = &decorated
+
+	es, err := fetchMasterEntityStatement(fedMasterURL, jwks, httpClient)
 	if err != nil {
 		return nil, err
 	}
 
 	if es.Metadata.FederationEntity == nil {
 		return nil, fmt.Errorf("no federation entity found in master entity statement")
-	}
-
-	httpClient := &http.Client{
-		Timeout:   10 * time.Second,
-		Transport: AddApiKeyTransport(http.DefaultTransport),
 	}
 
 	return &OpenidFederation{
@@ -83,8 +118,8 @@ func (f *OpenidFederation) FetchIdpList() ([]IdentityProviderInfo, error) {
 
 }
 
-func fetchMasterEntityStatement(fedMasterURL string, jwks jwk.Set) (*EntityStatement, error) {
-	resp, err := http.Get(fedMasterURL + "/.well-known/openid-federation")
+func fetchMasterEntityStatement(fedMasterURL string, jwks jwk.Set, httpClient *http.Client) (*EntityStatement, error) {
+	resp, err := httpClient.Get(fedMasterURL + "/.well-known/openid-federation")
 	if err != nil {
 		return nil, err
 	}
@@ -242,7 +277,7 @@ func (f *OpenidFederation) FetchSignedJwks(op *EntityStatement) (jwk.Set, error)
 
 	jwksUrl := op.Metadata.OpenidProvider.SignedJwksUri
 
-	resp, err := http.Get(jwksUrl)
+	resp, err := f.httpClient.Get(jwksUrl)
 	if err != nil {
 		return nil, fmt.Errorf("unable to fetch jwks from '%s': %w", jwksUrl, err)
 	}

--- a/go/oidf/relying_party.go
+++ b/go/oidf/relying_party.go
@@ -35,6 +35,11 @@ type RelyingPartyConfig struct {
 	ClientPrivateKeyPath string         `yaml:"client_private_key_path" validate:"required"`
 	ClientCertPath       string         `yaml:"client_cert_path" validate:"required"`
 	MetadataTemplate     map[string]any `yaml:"metadata_template" validate:"required"`
+
+	// HTTPClient is the base client for federation and relying-party calls. Not serialized; supplied
+	// programmatically. When nil, a client with a default timeout is created. The relying party's
+	// authenticated calls layer mutual TLS onto a copy of it.
+	HTTPClient *http.Client `yaml:"-"`
 }
 
 type RelyingParty struct {
@@ -113,14 +118,18 @@ func NewRelyingPartyFromConfig(cfg *RelyingPartyConfig) (*RelyingParty, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to load tls cert: %w", err)
 	}
-	rp.httpClient = &http.Client{
-		Timeout: 10 * time.Second,
-		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{
-				Certificates: []tls.Certificate{tlsCert},
-			},
-		},
+
+	baseClient := cfg.HTTPClient
+	if baseClient == nil {
+		baseClient = &http.Client{Timeout: defaultHTTPTimeout}
 	}
+	// the relying party's authenticated calls use mutual TLS; derive that client from the base
+	// without mutating the caller's
+	mtlsClient := *baseClient
+	mtlsClient.Transport = transportWithTLS(baseClient.Transport, &tls.Config{
+		Certificates: []tls.Certificate{tlsCert},
+	})
+	rp.httpClient = &mtlsClient
 
 	metadata, err := templateToMetadata(cfg.MetadataTemplate)
 	if err != nil {
@@ -146,7 +155,7 @@ func NewRelyingPartyFromConfig(cfg *RelyingPartyConfig) (*RelyingParty, error) {
 
 	rp.entityStatement.Metadata.OpenidRelyingParty.Jwks = &Jwks{Keys: entityJwks}
 
-	rp.federation, err = NewOpenidFederation(cfg.FedMasterURL, rp.trustAnchor)
+	rp.federation, err = NewOpenidFederation(cfg.FedMasterURL, rp.trustAnchor, WithHTTPClient(baseClient))
 	if err != nil {
 		return nil, err
 	}
@@ -334,6 +343,19 @@ func loadKeys(privateKeyPath string, kid string, keyUsage jwk.KeyUsageType, cert
 	}
 
 	return privateKey, publicKey, nil
+}
+
+// transportWithTLS clones the base transport (or http.DefaultTransport when the base is nil or not a
+// *http.Transport) and applies the given TLS config, so mutual TLS is layered onto the chosen client
+// without mutating it.
+func transportWithTLS(rt http.RoundTripper, tlsConfig *tls.Config) http.RoundTripper {
+	base, ok := transportOrDefault(rt).(*http.Transport)
+	if !ok {
+		base = http.DefaultTransport.(*http.Transport)
+	}
+	t := base.Clone()
+	t.TLSClientConfig = tlsConfig
+	return t
 }
 
 func (rp *RelyingParty) Federation() *OpenidFederation {

--- a/go/pep/pep.go
+++ b/go/pep/pep.go
@@ -17,6 +17,8 @@ import (
 	"github.com/lestrrat-go/jwx/v3/jwt"
 )
 
+const defaultHTTPTimeout = 30 * time.Second
+
 type PEP struct {
 	slogger                   *slog.Logger
 	httpClient                *http.Client
@@ -44,7 +46,7 @@ func (b *builder) Build() (*PEP, error) {
 		return nil, errors.New("none of the JWKSet provider has been set")
 	}
 	if b.p.httpClient == nil {
-		b.p.httpClient = http.DefaultClient
+		b.p.httpClient = &http.Client{Timeout: defaultHTTPTimeout}
 	}
 	if b.p.slogger == nil {
 		b.p.slogger = slog.Default()

--- a/go/pkcs12/cmd/pkcs12/main.go
+++ b/go/pkcs12/cmd/pkcs12/main.go
@@ -15,6 +15,7 @@ import (
 	"os"
 	"strings"
 	"syscall"
+	"time"
 
 	"github.com/gematik/zero-lab/go/pkcs12"
 	"github.com/gematik/zero-lab/go/pkcs12/legacy"
@@ -667,6 +668,7 @@ func requestCommand(args []string) {
 
 	// Create HTTP client
 	client := &http.Client{
+		Timeout: 30 * time.Second,
 		Transport: &http.Transport{
 			TLSClientConfig: tlsConfig,
 		},

--- a/go/ti/http_client.go
+++ b/go/ti/http_client.go
@@ -3,7 +3,12 @@ package main
 import (
 	"fmt"
 	"net/http"
+	"time"
 )
+
+// defaultHTTPTimeout is a backstop ceiling on TI HTTP requests; per-call context deadlines bound
+// individual operations.
+const defaultHTTPTimeout = 60 * time.Second
 
 // newHTTPClient returns an HTTP client with proxy support (HTTP_PROXY, HTTPS_PROXY,
 // NO_PROXY) and a User-Agent header on every request.
@@ -15,6 +20,7 @@ func newHTTPClient() *http.Client {
 
 func clientWithTransport(base http.RoundTripper) *http.Client {
 	return &http.Client{
+		Timeout:   defaultHTTPTimeout,
 		Transport: &userAgentTransport{base: base},
 	}
 }


### PR DESCRIPTION
Every module that performs outbound HTTP now lets a caller supply an *http.Client through its public API (a Config field, a functional option, or a func param), so timeouts, proxy, TLS and instrumentation are the caller's to control:

- oauth/oidc: Config.HTTPClient; FetchDiscoveryDocument takes a client; the JWK cache uses it via httprc.WithHTTPClient.
- gemidp: ClientConfig/AuthenticatorConfig HTTPClient; fetchKey/fetchMetadata take the client; the User-Agent transport and no-follow redirect policy are layered on.
- oidf: NewOpenidFederation gains a WithHTTPClient option; RelyingPartyConfig.HTTPClient; the API-key transport and mutual-TLS cert are layered on.
- epa: WithHTTPClient option; the User-Agent transport and TLS settings are layered on.
- kon: WithHTTPClient option; the connector mutual-TLS is layered onto the chosen client; the request ceiling tracks the configured LongTimeout instead of a fixed value.

When no client is supplied a module builds its own, but always with an explicit, non-zero Timeout (never http.DefaultClient). Decoration copies the client and clones the transport, so a caller-supplied client is never mutated. gempki and pep no longer fall back to http.DefaultClient, and the ti and pkcs12 CLIs set an explicit Timeout.